### PR TITLE
Add FAQs

### DIFF
--- a/pento/lib/pento/frequently_asked_questions.ex
+++ b/pento/lib/pento/frequently_asked_questions.ex
@@ -1,0 +1,104 @@
+defmodule Pento.FrequentlyAskedQuestions do
+  @moduledoc """
+  The FrequentlyAskedQuestions context.
+  """
+
+  import Ecto.Query, warn: false
+  alias Pento.Repo
+
+  alias Pento.FrequentlyAskedQuestions.Question
+
+  @doc """
+  Returns the list of questions.
+
+  ## Examples
+
+      iex> list_questions()
+      [%Question{}, ...]
+
+  """
+  def list_questions do
+    Repo.all(Question)
+  end
+
+  @doc """
+  Gets a single question.
+
+  Raises `Ecto.NoResultsError` if the Question does not exist.
+
+  ## Examples
+
+      iex> get_question!(123)
+      %Question{}
+
+      iex> get_question!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_question!(id), do: Repo.get!(Question, id)
+
+  @doc """
+  Creates a question.
+
+  ## Examples
+
+      iex> create_question(%{field: value})
+      {:ok, %Question{}}
+
+      iex> create_question(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_question(attrs \\ %{}) do
+    %Question{}
+    |> Question.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a question.
+
+  ## Examples
+
+      iex> update_question(question, %{field: new_value})
+      {:ok, %Question{}}
+
+      iex> update_question(question, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_question(%Question{} = question, attrs) do
+    question
+    |> Question.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a question.
+
+  ## Examples
+
+      iex> delete_question(question)
+      {:ok, %Question{}}
+
+      iex> delete_question(question)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_question(%Question{} = question) do
+    Repo.delete(question)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking question changes.
+
+  ## Examples
+
+      iex> change_question(question)
+      %Ecto.Changeset{data: %Question{}}
+
+  """
+  def change_question(%Question{} = question, attrs \\ %{}) do
+    Question.changeset(question, attrs)
+  end
+end

--- a/pento/lib/pento/frequently_asked_questions.ex
+++ b/pento/lib/pento/frequently_asked_questions.ex
@@ -101,4 +101,8 @@ defmodule Pento.FrequentlyAskedQuestions do
   def change_question(%Question{} = question, attrs \\ %{}) do
     Question.changeset(question, attrs)
   end
+
+  def upvote(%Question{votes: votes} = question) do
+    Question.changeset(question, %{votes: votes + 1}) |> Repo.update()
+  end
 end

--- a/pento/lib/pento/frequently_asked_questions/question.ex
+++ b/pento/lib/pento/frequently_asked_questions/question.ex
@@ -1,0 +1,19 @@
+defmodule Pento.FrequentlyAskedQuestions.Question do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "questions" do
+    field :question, :string
+    field :answer, :string, default: nil
+    field :votes, :integer, default: 0
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(question, attrs) do
+    question
+    |> cast(attrs, [:question, :answer, :votes])
+    |> validate_required([:question])
+  end
+end

--- a/pento/lib/pento_web/live/question_live/form_component.ex
+++ b/pento/lib/pento_web/live/question_live/form_component.ex
@@ -1,0 +1,92 @@
+defmodule PentoWeb.QuestionLive.FormComponent do
+  use PentoWeb, :live_component
+
+  alias Pento.FrequentlyAskedQuestions
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div>
+      <.header>
+        <%= @title %>
+        <:subtitle>Use this form to manage question records in your database.</:subtitle>
+      </.header>
+
+      <.simple_form
+        for={@form}
+        id="question-form"
+        phx-target={@myself}
+        phx-change="validate"
+        phx-submit="save"
+      >
+        <.input field={@form[:question]} type="text" label="Question" />
+        <.input field={@form[:answer]} type="text" label="Answer" />
+        <.input field={@form[:votes]} type="number" label="Votes" />
+        <:actions>
+          <.button phx-disable-with="Saving...">Save Question</.button>
+        </:actions>
+      </.simple_form>
+    </div>
+    """
+  end
+
+  @impl true
+  def update(%{question: question} = assigns, socket) do
+    changeset = FrequentlyAskedQuestions.change_question(question)
+
+    {:ok,
+     socket
+     |> assign(assigns)
+     |> assign_form(changeset)}
+  end
+
+  @impl true
+  def handle_event("validate", %{"question" => question_params}, socket) do
+    changeset =
+      socket.assigns.question
+      |> FrequentlyAskedQuestions.change_question(question_params)
+      |> Map.put(:action, :validate)
+
+    {:noreply, assign_form(socket, changeset)}
+  end
+
+  def handle_event("save", %{"question" => question_params}, socket) do
+    save_question(socket, socket.assigns.action, question_params)
+  end
+
+  defp save_question(socket, :edit, question_params) do
+    case FrequentlyAskedQuestions.update_question(socket.assigns.question, question_params) do
+      {:ok, question} ->
+        notify_parent({:saved, question})
+
+        {:noreply,
+         socket
+         |> put_flash(:info, "Question updated successfully")
+         |> push_patch(to: socket.assigns.patch)}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign_form(socket, changeset)}
+    end
+  end
+
+  defp save_question(socket, :new, question_params) do
+    case FrequentlyAskedQuestions.create_question(question_params) do
+      {:ok, question} ->
+        notify_parent({:saved, question})
+
+        {:noreply,
+         socket
+         |> put_flash(:info, "Question created successfully")
+         |> push_patch(to: socket.assigns.patch)}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign_form(socket, changeset)}
+    end
+  end
+
+  defp assign_form(socket, %Ecto.Changeset{} = changeset) do
+    assign(socket, :form, to_form(changeset))
+  end
+
+  defp notify_parent(msg), do: send(self(), {__MODULE__, msg})
+end

--- a/pento/lib/pento_web/live/question_live/index.ex
+++ b/pento/lib/pento_web/live/question_live/index.ex
@@ -44,4 +44,13 @@ defmodule PentoWeb.QuestionLive.Index do
 
     {:noreply, stream_delete(socket, :questions, question)}
   end
+
+  @impl true
+  def handle_event("upvote", %{"id" => id}, socket) do
+    question = FrequentlyAskedQuestions.get_question!(id)
+    {:ok, _} = FrequentlyAskedQuestions.upvote(question)
+
+    # TODO this is not very elegant
+    {:noreply, stream_insert(socket, :questions, %Question{question | votes: question.votes + 1})}
+  end
 end

--- a/pento/lib/pento_web/live/question_live/index.ex
+++ b/pento/lib/pento_web/live/question_live/index.ex
@@ -1,0 +1,47 @@
+defmodule PentoWeb.QuestionLive.Index do
+  use PentoWeb, :live_view
+
+  alias Pento.FrequentlyAskedQuestions
+  alias Pento.FrequentlyAskedQuestions.Question
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok, stream(socket, :questions, FrequentlyAskedQuestions.list_questions())}
+  end
+
+  @impl true
+  def handle_params(params, _url, socket) do
+    {:noreply, apply_action(socket, socket.assigns.live_action, params)}
+  end
+
+  defp apply_action(socket, :edit, %{"id" => id}) do
+    socket
+    |> assign(:page_title, "Edit Question")
+    |> assign(:question, FrequentlyAskedQuestions.get_question!(id))
+  end
+
+  defp apply_action(socket, :new, _params) do
+    socket
+    |> assign(:page_title, "New Question")
+    |> assign(:question, %Question{})
+  end
+
+  defp apply_action(socket, :index, _params) do
+    socket
+    |> assign(:page_title, "Listing Questions")
+    |> assign(:question, nil)
+  end
+
+  @impl true
+  def handle_info({PentoWeb.QuestionLive.FormComponent, {:saved, question}}, socket) do
+    {:noreply, stream_insert(socket, :questions, question)}
+  end
+
+  @impl true
+  def handle_event("delete", %{"id" => id}, socket) do
+    question = FrequentlyAskedQuestions.get_question!(id)
+    {:ok, _} = FrequentlyAskedQuestions.delete_question(question)
+
+    {:noreply, stream_delete(socket, :questions, question)}
+  end
+end

--- a/pento/lib/pento_web/live/question_live/index.ex
+++ b/pento/lib/pento_web/live/question_live/index.ex
@@ -50,7 +50,6 @@ defmodule PentoWeb.QuestionLive.Index do
     question = FrequentlyAskedQuestions.get_question!(id)
     {:ok, _} = FrequentlyAskedQuestions.upvote(question)
 
-    # TODO this is not very elegant
     {:noreply, stream_insert(socket, :questions, %Question{question | votes: question.votes + 1})}
   end
 end

--- a/pento/lib/pento_web/live/question_live/index.html.heex
+++ b/pento/lib/pento_web/live/question_live/index.html.heex
@@ -1,0 +1,43 @@
+<.header>
+  Listing Questions
+  <:actions>
+    <.link patch={~p"/questions/new"}>
+      <.button>New Question</.button>
+    </.link>
+  </:actions>
+</.header>
+
+<.table
+  id="questions"
+  rows={@streams.questions}
+  row_click={fn {_id, question} -> JS.navigate(~p"/questions/#{question}") end}
+>
+  <:col :let={{_id, question}} label="Question"><%= question.question %></:col>
+  <:col :let={{_id, question}} label="Answer"><%= question.answer %></:col>
+  <:col :let={{_id, question}} label="Votes"><%= question.votes %></:col>
+  <:action :let={{_id, question}}>
+    <div class="sr-only">
+      <.link navigate={~p"/questions/#{question}"}>Show</.link>
+    </div>
+    <.link patch={~p"/questions/#{question}/edit"}>Edit</.link>
+  </:action>
+  <:action :let={{id, question}}>
+    <.link
+      phx-click={JS.push("delete", value: %{id: question.id}) |> hide("##{id}")}
+      data-confirm="Are you sure?"
+    >
+      Delete
+    </.link>
+  </:action>
+</.table>
+
+<.modal :if={@live_action in [:new, :edit]} id="question-modal" show on_cancel={JS.patch(~p"/questions")}>
+  <.live_component
+    module={PentoWeb.QuestionLive.FormComponent}
+    id={@question.id || :new}
+    title={@page_title}
+    action={@live_action}
+    question={@question}
+    patch={~p"/questions"}
+  />
+</.modal>

--- a/pento/lib/pento_web/live/question_live/index.html.heex
+++ b/pento/lib/pento_web/live/question_live/index.html.heex
@@ -29,9 +29,19 @@
       Delete
     </.link>
   </:action>
+  <:action :let={{id, question}}>
+    <.link phx-click={JS.push("upvote", value: %{id: question.id})}>
+      Upvote
+    </.link>
+  </:action>
 </.table>
 
-<.modal :if={@live_action in [:new, :edit]} id="question-modal" show on_cancel={JS.patch(~p"/questions")}>
+<.modal
+  :if={@live_action in [:new, :edit]}
+  id="question-modal"
+  show
+  on_cancel={JS.patch(~p"/questions")}
+>
   <.live_component
     module={PentoWeb.QuestionLive.FormComponent}
     id={@question.id || :new}

--- a/pento/lib/pento_web/live/question_live/show.ex
+++ b/pento/lib/pento_web/live/question_live/show.ex
@@ -1,0 +1,21 @@
+defmodule PentoWeb.QuestionLive.Show do
+  use PentoWeb, :live_view
+
+  alias Pento.FrequentlyAskedQuestions
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_params(%{"id" => id}, _, socket) do
+    {:noreply,
+     socket
+     |> assign(:page_title, page_title(socket.assigns.live_action))
+     |> assign(:question, FrequentlyAskedQuestions.get_question!(id))}
+  end
+
+  defp page_title(:show), do: "Show Question"
+  defp page_title(:edit), do: "Edit Question"
+end

--- a/pento/lib/pento_web/live/question_live/show.ex
+++ b/pento/lib/pento_web/live/question_live/show.ex
@@ -2,6 +2,7 @@ defmodule PentoWeb.QuestionLive.Show do
   use PentoWeb, :live_view
 
   alias Pento.FrequentlyAskedQuestions
+  alias Pento.FrequentlyAskedQuestions.Question
 
   @impl true
   def mount(_params, _session, socket) do
@@ -18,4 +19,16 @@ defmodule PentoWeb.QuestionLive.Show do
 
   defp page_title(:show), do: "Show Question"
   defp page_title(:edit), do: "Edit Question"
+
+  def handle_event("upvote", %{"id" => id}, socket) do
+    question = FrequentlyAskedQuestions.get_question!(id)
+    {:ok, _} = FrequentlyAskedQuestions.upvote(question)
+
+    {:noreply,
+     socket
+     |> assign(:question, %Question{
+       question
+       | votes: question.votes + 1
+     })}
+  end
 end

--- a/pento/lib/pento_web/live/question_live/show.ex
+++ b/pento/lib/pento_web/live/question_live/show.ex
@@ -20,6 +20,7 @@ defmodule PentoWeb.QuestionLive.Show do
   defp page_title(:show), do: "Show Question"
   defp page_title(:edit), do: "Edit Question"
 
+  @impl true
   def handle_event("upvote", %{"id" => id}, socket) do
     question = FrequentlyAskedQuestions.get_question!(id)
     {:ok, _} = FrequentlyAskedQuestions.upvote(question)

--- a/pento/lib/pento_web/live/question_live/show.html.heex
+++ b/pento/lib/pento_web/live/question_live/show.html.heex
@@ -1,0 +1,28 @@
+<.header>
+  Question <%= @question.id %>
+  <:subtitle>This is a question record from your database.</:subtitle>
+  <:actions>
+    <.link patch={~p"/questions/#{@question}/show/edit"} phx-click={JS.push_focus()}>
+      <.button>Edit question</.button>
+    </.link>
+  </:actions>
+</.header>
+
+<.list>
+  <:item title="Question"><%= @question.question %></:item>
+  <:item title="Answer"><%= @question.answer %></:item>
+  <:item title="Votes"><%= @question.votes %></:item>
+</.list>
+
+<.back navigate={~p"/questions"}>Back to questions</.back>
+
+<.modal :if={@live_action == :edit} id="question-modal" show on_cancel={JS.patch(~p"/questions/#{@question}")}>
+  <.live_component
+    module={PentoWeb.QuestionLive.FormComponent}
+    id={@question.id}
+    title={@page_title}
+    action={@live_action}
+    question={@question}
+    patch={~p"/questions/#{@question}"}
+  />
+</.modal>

--- a/pento/lib/pento_web/live/question_live/show.html.heex
+++ b/pento/lib/pento_web/live/question_live/show.html.heex
@@ -5,6 +5,9 @@
     <.link patch={~p"/questions/#{@question}/show/edit"} phx-click={JS.push_focus()}>
       <.button>Edit question</.button>
     </.link>
+    <.link phx-click={JS.push("upvote", value: %{id: @question.id})}>
+      <.button>Upvote</.button>
+    </.link>
   </:actions>
 </.header>
 
@@ -16,7 +19,12 @@
 
 <.back navigate={~p"/questions"}>Back to questions</.back>
 
-<.modal :if={@live_action == :edit} id="question-modal" show on_cancel={JS.patch(~p"/questions/#{@question}")}>
+<.modal
+  :if={@live_action == :edit}
+  id="question-modal"
+  show
+  on_cancel={JS.patch(~p"/questions/#{@question}")}
+>
   <.live_component
     module={PentoWeb.QuestionLive.FormComponent}
     id={@question.id}

--- a/pento/lib/pento_web/router.ex
+++ b/pento/lib/pento_web/router.ex
@@ -84,6 +84,13 @@ defmodule PentoWeb.Router do
       live "/products/:id", ProductLive.Show, :show
       live "/products/:id/show/edit", ProductLive.Show, :edit
       live "/products/:id/show/mark_down", ProductLive.Show, :mark_down
+
+      live "/questions", QuestionLive.Index, :index
+      live "/questions/new", QuestionLive.Index, :new
+      live "/questions/:id/edit", QuestionLive.Index, :edit
+
+      live "/questions/:id", QuestionLive.Show, :show
+      live "/questions/:id/show/edit", QuestionLive.Show, :edit
     end
   end
 

--- a/pento/priv/repo/migrations/20240213172120_create_questions.exs
+++ b/pento/priv/repo/migrations/20240213172120_create_questions.exs
@@ -1,0 +1,13 @@
+defmodule Pento.Repo.Migrations.CreateQuestions do
+  use Ecto.Migration
+
+  def change do
+    create table(:questions) do
+      add :question, :string
+      add :answer, :string
+      add :votes, :integer
+
+      timestamps()
+    end
+  end
+end

--- a/pento/test/pento/frequently_asked_questions_test.exs
+++ b/pento/test/pento/frequently_asked_questions_test.exs
@@ -1,0 +1,63 @@
+defmodule Pento.FrequentlyAskedQuestionsTest do
+  use Pento.DataCase
+
+  alias Pento.FrequentlyAskedQuestions
+
+  describe "questions" do
+    alias Pento.FrequentlyAskedQuestions.Question
+
+    import Pento.FrequentlyAskedQuestionsFixtures
+
+    @invalid_attrs %{question: nil, answer: nil, votes: nil}
+
+    test "list_questions/0 returns all questions" do
+      question = question_fixture()
+      assert FrequentlyAskedQuestions.list_questions() == [question]
+    end
+
+    test "get_question!/1 returns the question with given id" do
+      question = question_fixture()
+      assert FrequentlyAskedQuestions.get_question!(question.id) == question
+    end
+
+    test "create_question/1 with valid data creates a question" do
+      valid_attrs = %{question: "some question", answer: "some answer", votes: 42}
+
+      assert {:ok, %Question{} = question} = FrequentlyAskedQuestions.create_question(valid_attrs)
+      assert question.question == "some question"
+      assert question.answer == "some answer"
+      assert question.votes == 42
+    end
+
+    test "create_question/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = FrequentlyAskedQuestions.create_question(@invalid_attrs)
+    end
+
+    test "update_question/2 with valid data updates the question" do
+      question = question_fixture()
+      update_attrs = %{question: "some updated question", answer: "some updated answer", votes: 43}
+
+      assert {:ok, %Question{} = question} = FrequentlyAskedQuestions.update_question(question, update_attrs)
+      assert question.question == "some updated question"
+      assert question.answer == "some updated answer"
+      assert question.votes == 43
+    end
+
+    test "update_question/2 with invalid data returns error changeset" do
+      question = question_fixture()
+      assert {:error, %Ecto.Changeset{}} = FrequentlyAskedQuestions.update_question(question, @invalid_attrs)
+      assert question == FrequentlyAskedQuestions.get_question!(question.id)
+    end
+
+    test "delete_question/1 deletes the question" do
+      question = question_fixture()
+      assert {:ok, %Question{}} = FrequentlyAskedQuestions.delete_question(question)
+      assert_raise Ecto.NoResultsError, fn -> FrequentlyAskedQuestions.get_question!(question.id) end
+    end
+
+    test "change_question/1 returns a question changeset" do
+      question = question_fixture()
+      assert %Ecto.Changeset{} = FrequentlyAskedQuestions.change_question(question)
+    end
+  end
+end

--- a/pento/test/pento_web/live/question_live_test.exs
+++ b/pento/test/pento_web/live/question_live_test.exs
@@ -1,0 +1,113 @@
+defmodule PentoWeb.QuestionLiveTest do
+  use PentoWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+  import Pento.FrequentlyAskedQuestionsFixtures
+
+  @create_attrs %{question: "some question", answer: "some answer", votes: 42}
+  @update_attrs %{question: "some updated question", answer: "some updated answer", votes: 43}
+  @invalid_attrs %{question: nil, answer: nil, votes: nil}
+
+  defp create_question(_) do
+    question = question_fixture()
+    %{question: question}
+  end
+
+  describe "Index" do
+    setup [:create_question]
+
+    test "lists all questions", %{conn: conn, question: question} do
+      {:ok, _index_live, html} = live(conn, ~p"/questions")
+
+      assert html =~ "Listing Questions"
+      assert html =~ question.question
+    end
+
+    test "saves new question", %{conn: conn} do
+      {:ok, index_live, _html} = live(conn, ~p"/questions")
+
+      assert index_live |> element("a", "New Question") |> render_click() =~
+               "New Question"
+
+      assert_patch(index_live, ~p"/questions/new")
+
+      assert index_live
+             |> form("#question-form", question: @invalid_attrs)
+             |> render_change() =~ "can&#39;t be blank"
+
+      assert index_live
+             |> form("#question-form", question: @create_attrs)
+             |> render_submit()
+
+      assert_patch(index_live, ~p"/questions")
+
+      html = render(index_live)
+      assert html =~ "Question created successfully"
+      assert html =~ "some question"
+    end
+
+    test "updates question in listing", %{conn: conn, question: question} do
+      {:ok, index_live, _html} = live(conn, ~p"/questions")
+
+      assert index_live |> element("#questions-#{question.id} a", "Edit") |> render_click() =~
+               "Edit Question"
+
+      assert_patch(index_live, ~p"/questions/#{question}/edit")
+
+      assert index_live
+             |> form("#question-form", question: @invalid_attrs)
+             |> render_change() =~ "can&#39;t be blank"
+
+      assert index_live
+             |> form("#question-form", question: @update_attrs)
+             |> render_submit()
+
+      assert_patch(index_live, ~p"/questions")
+
+      html = render(index_live)
+      assert html =~ "Question updated successfully"
+      assert html =~ "some updated question"
+    end
+
+    test "deletes question in listing", %{conn: conn, question: question} do
+      {:ok, index_live, _html} = live(conn, ~p"/questions")
+
+      assert index_live |> element("#questions-#{question.id} a", "Delete") |> render_click()
+      refute has_element?(index_live, "#questions-#{question.id}")
+    end
+  end
+
+  describe "Show" do
+    setup [:create_question]
+
+    test "displays question", %{conn: conn, question: question} do
+      {:ok, _show_live, html} = live(conn, ~p"/questions/#{question}")
+
+      assert html =~ "Show Question"
+      assert html =~ question.question
+    end
+
+    test "updates question within modal", %{conn: conn, question: question} do
+      {:ok, show_live, _html} = live(conn, ~p"/questions/#{question}")
+
+      assert show_live |> element("a", "Edit") |> render_click() =~
+               "Edit Question"
+
+      assert_patch(show_live, ~p"/questions/#{question}/show/edit")
+
+      assert show_live
+             |> form("#question-form", question: @invalid_attrs)
+             |> render_change() =~ "can&#39;t be blank"
+
+      assert show_live
+             |> form("#question-form", question: @update_attrs)
+             |> render_submit()
+
+      assert_patch(show_live, ~p"/questions/#{question}")
+
+      html = render(show_live)
+      assert html =~ "Question updated successfully"
+      assert html =~ "some updated question"
+    end
+  end
+end

--- a/pento/test/pento_web/live/question_live_test.exs
+++ b/pento/test/pento_web/live/question_live_test.exs
@@ -14,7 +14,7 @@ defmodule PentoWeb.QuestionLiveTest do
   end
 
   describe "Index" do
-    setup [:create_question]
+    setup [:create_question, :register_and_log_in_user]
 
     test "lists all questions", %{conn: conn, question: question} do
       {:ok, _index_live, html} = live(conn, ~p"/questions")
@@ -78,7 +78,7 @@ defmodule PentoWeb.QuestionLiveTest do
   end
 
   describe "Show" do
-    setup [:create_question]
+    setup [:create_question, :register_and_log_in_user]
 
     test "displays question", %{conn: conn, question: question} do
       {:ok, _show_live, html} = live(conn, ~p"/questions/#{question}")

--- a/pento/test/support/fixtures/frequently_asked_questions_fixtures.ex
+++ b/pento/test/support/fixtures/frequently_asked_questions_fixtures.ex
@@ -1,0 +1,22 @@
+defmodule Pento.FrequentlyAskedQuestionsFixtures do
+  @moduledoc """
+  This module defines test helpers for creating
+  entities via the `Pento.FrequentlyAskedQuestions` context.
+  """
+
+  @doc """
+  Generate a question.
+  """
+  def question_fixture(attrs \\ %{}) do
+    {:ok, question} =
+      attrs
+      |> Enum.into(%{
+        answer: "some answer",
+        question: "some question",
+        votes: 42
+      })
+      |> Pento.FrequentlyAskedQuestions.create_question()
+
+    question
+  end
+end


### PR DESCRIPTION
TO DO:

> You’ll run the Phoenix Live generator again to create a new set of CRUD features for a resource, FAQ, or “frequently asked question”. This feature will allow users of our gaming site to submit questions, answer them, and up-vote them. Each FAQ should have fields for a question, an answer, and a vote count.
> Devise your generator command and run it. Then, fire up the Phoenix server and interact with your generated FAQ CRUD features! Can you create a new question? Can you answer it? Trace some of the generated code pathways that support this functionality.

* Created using command `mix phx.gen.live FrequentlyAskedQuestions Question questions question:string answer:string votes:integer`
* Updated the changeset/schema to have default values of nil/0 for answer and votes, and to not require the latter two. Probably would be a good idea to have a separate changeset for upvotes only.